### PR TITLE
Fix memory-safety bugs, OOB read, and build incrementality

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -145,8 +145,12 @@ $(PNAMEDYNAMICLIB): $(REALNAME) $(CSTLEMMAOBJ)
 
 all: $(PNAMESTATIC) $(PNAMEDYNAMIC) $(REALNAME) $(PNAMEDYNAMICLIB)
 
+# Let make locate sources living in the sibling lib directories so each object
+# can be compiled individually (see the .cpp.o rule below).
+vpath %.cpp $(SRCDIR) $(HASHDIR) $(LETTERFUNCDIR) $(SGMLDIR)
+
 .cpp.o:
-	$(CC) $(PIC) $(DEBUG) $(GCCINC) -c $(CSTLEMMASRC) $(LEMMATISERSRC)
+	$(CC) $(PIC) $(DEBUG) $(GCCINC) -c $< -o $@
 
 clean:
 	$(RM) *.o

--- a/src/applyrules.cpp
+++ b/src/applyrules.cpp
@@ -833,7 +833,7 @@ static char * rewrite(const char *& word, const char *& wordend, const char * p
 #if PRINTRULE
             if (beginOfWord)
                 {
-                rule = printpat(fields, findex, beginOfWord, word-beginOfWord, wordend);
+                rule = printpat(fields, findex, beginOfWord, (int)(word-beginOfWord), wordend);
                 }
 #endif
             }
@@ -845,7 +845,7 @@ static char * rewrite(const char *& word, const char *& wordend, const char * p
 #if PRINTRULE
             if (beginOfWord)
                 {
-                rule = printpat(fields, findex, beginOfWord, vars[0].s - beginOfWord, wordend);
+                rule = printpat(fields, findex, beginOfWord, (int)(vars[0].s - beginOfWord), wordend);
                 }
 #endif
             }

--- a/src/applyrules.cpp
+++ b/src/applyrules.cpp
@@ -942,22 +942,26 @@ static char * concat(LemmaRule * L)
             }
         ++lngth;
         char * ret = new char[lngth];
-        ret[0] = 0;
+        char * w = ret; // running write pointer: avoids O(n^2) strcat rescans
         for (i = 0; L[i].Lem; ++i)
             {
-            strcat(ret, L[i].Lem);
+            size_t l = strlen(L[i].Lem);
+            memcpy(w, L[i].Lem, l);
+            w += l;
             delete[] L[i].Lem;
             L[i].Lem = 0;
 #if PRINTRULE
-            strcat(ret, "\v");
-            strcat(ret, L[i].rule);
+            *w++ = '\v';
+            size_t lr = strlen(L[i].rule);
+            memcpy(w, L[i].rule, lr);
+            w += lr;
             delete[] L[i].rule;
             L[i].rule = 0;
 #endif
-            strcat(ret, " ");
+            *w++ = ' ';
             }
         delete[] L;
-        ret[lngth-1] = 0;
+        ret[lngth-1] = 0; // w == ret + (lngth-1); terminate (trailing space kept, as before)
         return ret;
         }
     else

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -55,7 +55,7 @@ char * readValue::read(char * kar,field *& nextfield)
             len = pos + ln + 1;
             char * nw = new char[len];
             strcpy(nw,word);
-            delete word;
+            delete[] word;
             word = nw;
             }
         strcpy(word + pos,nxt);
@@ -176,12 +176,12 @@ void readLitteral::add(char kar)
     {
     ++len;
     char * nw = new char[len];
-    delete matched;
+    delete[] matched;
     matched = new char[len];
     strcpy(nw,litteral);
     nw[len-2] = kar;
     nw[len-1] = '\0';
-    delete litteral;
+    delete[] litteral;
     litteral = nw;
     }
 
@@ -210,7 +210,7 @@ char * readLitteral::read(char * kar,field *& nextfield)
                     {
                     if(givebacklen <= j)
                         {
-                        delete giveback;
+                        delete[] giveback;
                         giveback = new char[j+1];
                         }
                     int k;

--- a/src/field.h
+++ b/src/field.h
@@ -90,7 +90,7 @@ class readValue : public field
             }
         ~readValue()
             {
-            delete word;
+            delete[] word;
             }
         void reset()
             {
@@ -195,8 +195,9 @@ class readLitteral : public field
         readLitteral(char first);
         ~readLitteral()
             {
-            delete litteral;
-            delete giveback;
+            delete[] litteral;
+            delete[] matched;
+            delete[] giveback;
             }
         void add(char kar);
         virtual char * read(char * kar,field *& nextfield);

--- a/src/flattext.cpp
+++ b/src/flattext.cpp
@@ -341,7 +341,7 @@ void flattext::printUnsorted(
     REFER(fpo) // unused
         for (k = 0; k < total; ++k)
             {
-            while (k >= Lines[line] && line <= lineno)
+            while (line <= lineno && k >= Lines[line])
                 {
                 Word::NewLinesAfterWord++;
                 ++line;

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -842,6 +842,7 @@ void text::createTagged(const char * w, const char * tag)
 
 text::text(bool a_InputHasTags,bool nice)
            :Root(0)
+           ,Lines(0)
            ,lineno(0)
            ,total(0)
            ,reducedtotal(0)
@@ -863,7 +864,8 @@ text::text(bool a_InputHasTags,bool nice)
 text::~text()
     {
     delete fields;
-    delete Root;
+    delete[] Root;
+    delete[] Lines;
 #ifdef COUNTOBJECTS
     --COUNT;
 #endif

--- a/src/trigramdisamb.cpp
+++ b/src/trigramdisamb.cpp
@@ -214,7 +214,7 @@ const char* trigramdisamb::sortByWeight(char* strings, bool RulesUnique)
     char* tmp = new char[len + 1];
     int cnt = 0;
     strcpy(tmp, strings);
-    for(int i = strlen(tmp); --i >= 0;)
+    for(int i = (int)strlen(tmp); --i >= 0;)
         {
         if(tmp[i] == ' ')
             {


### PR DESCRIPTION
Memory safety (new[]/delete mismatches — UB, found via AddressSanitizer): field.cpp/field.h use delete[] for char[] buffers in readValue/readLitteral and free the leaked `matched` buffer; text.cpp uses delete[] Root and initializes/frees the new[]-allocated Lines buffer in ~text().

OOB read (flattext.cpp): reorder && so the `line <= lineno` bound check short-circuits before indexing Lines[line].

Performance (applyrules.cpp): concat() rewritten O(n^2)->O(n) with a running write pointer; output byte-identical.

Build (Makefile): per-file compilation (-c $< -o $@) + vpath for sibling lib sources, enabling real incremental builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)